### PR TITLE
Update getURL() to use configured endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -258,6 +258,21 @@ Also, if you are using a CDN such as cloudfront that automatically mirrors the c
 
 Note that specifying a CDN in this way does not in any way activate that CDN for you. It just tells `uploadfs` to return a different result from `getUrl`. The rest is up to you. More CDN-related options may be added in the future.
 
+## Use with object storage services which implement the S3 api
+
+It is possible to use uploadfs with storage services that implement an api compatible with amazon AWS and S3. One example of this would be IBM Cloud's 'Object Storage'. To enable use of another storage service, simply provide the appropriate endpoint:
+
+```javascript
+  endpoint: 'api-domain.yourstorageprovider.com'
+```
+
+It is possible that if your storage provider and application are hosted on different domains, you will need to setup cross origin resource sharing (CORS) before everything will work perfectly. If you enable the CORS option most of the work should be done for you, but you will have to provide a list of domains you want accessing your stored images. Like so:
+
+```javascript
+  cors: true,
+  origins: ['localhost', 'yoursitedomain.com']
+```
+
 ## Important Concerns With S3
 
 **Be aware that uploads to Amazon S3's us-standard region are not guaranteed to be readable the moment you finish uploading them.** This is a big difference from how a regular filesystem behaves. One browser might see them right away while another does not. This is called "eventual consistency."

--- a/README.md
+++ b/README.md
@@ -266,13 +266,6 @@ It is possible to use uploadfs with storage services that implement an api compa
   endpoint: 'api-domain.yourstorageprovider.com'
 ```
 
-It is possible that if your storage provider and application are hosted on different domains, you will need to setup cross origin resource sharing (CORS) before everything will work perfectly. If you enable the CORS option most of the work should be done for you, but you will have to provide a list of domains you want accessing your stored images. Like so:
-
-```javascript
-  cors: true,
-  origins: ['localhost', 'yoursitedomain.com']
-```
-
 ## Important Concerns With S3
 
 **Be aware that uploads to Amazon S3's us-standard region are not guaranteed to be readable the moment you finish uploading them.** This is a big difference from how a regular filesystem behaves. One browser might see them right away while another does not. This is called "eventual consistency."

--- a/lib/storage/s3.js
+++ b/lib/storage/s3.js
@@ -103,9 +103,16 @@ module.exports = function() {
       if (options.cors) {
         // CORS
         return client.getBucketCors(getCorsConfig, function (err, data) {
-          if (err) { // an error occurred
-            return callback(err);
-          } else { // successful response
+          if (err) {
+            // No CORS yet.
+            if (err.message == "NoSuchCORSConfiguration: The CORS configuration does not exist") {
+              return client.putBucketCors(putCorsConfig, callback);
+            // Unexpected error
+            } else {
+              return callback(err);
+            }
+          // Successful response
+          } else {
             if (_.isEqual(data.CORSRules, putCorsConfig.CORSConfiguration.CORSRules) == false) {
               return client.putBucketCors(putCorsConfig, callback);
             } else {

--- a/lib/storage/s3.js
+++ b/lib/storage/s3.js
@@ -111,7 +111,7 @@ module.exports = function() {
                 return client.putBucketCors(putCorsConfig, callback);
                 // Unexpected error
               } else {
-                console.log("Unexpected error");
+                console.log("Unexpected error: ", err.message);
                 return callback(err);
               }
               // Successful response

--- a/lib/storage/s3.js
+++ b/lib/storage/s3.js
@@ -106,10 +106,12 @@ module.exports = function() {
           return client.getBucketCors(getCorsConfig, function (err, data) {
             if (err) {
               // No CORS yet.
-              if (err.message == "NoSuchCORSConfiguration: The CORS configuration does not exist") {
+              if (err.message.indexOf("NoSuchCORSConfiguration") >= 0) {
+                console.log("Creating CORS Config");
                 return client.putBucketCors(putCorsConfig, callback);
                 // Unexpected error
               } else {
+                console.log("Unexpected error");
                 return callback(err);
               }
               // Successful response

--- a/lib/storage/s3.js
+++ b/lib/storage/s3.js
@@ -106,7 +106,7 @@ module.exports = function() {
           return client.getBucketCors(getCorsConfig, function (err, data) {
             if (err) {
               // No CORS yet.
-              if (err.message.indexOf("NoSuchCORSConfiguration") >= 0) {
+              if (err.message.indexOf("The CORS configuration does not exist") >= 0) {
                 console.log("Creating CORS Config");
                 return client.putBucketCors(putCorsConfig, callback);
                 // Unexpected error

--- a/lib/storage/s3.js
+++ b/lib/storage/s3.js
@@ -117,9 +117,30 @@ module.exports = function() {
               // Successful response
             } else {
               if (_.isEqual(data.CORSRules, putCorsConfig.CORSConfiguration.CORSRules) == false) {
-                return client.putBucketCors(putCorsConfig, callback);
-              } else {
                 return callback(null);
+              } else {
+                // Collect all the existing origins
+                var curOrigins = new Array;
+                for (i = 0; i < data.CORSRules.length(); i++) {
+                  var iOrigins = data.CORSRules[i].AllowedOrigins;
+                  for (j = 0; j < iOrigins.length(); j++) {
+                    var origin = iOrigins[j];
+                    if (curOrigins.indexOf(origin) < 0 && origin != "*") {
+                      curOrigins.push(origin);
+                    }
+                  }
+                }
+                // Add new origins
+                for (k = 0; k < options.origins.length(); k++) {
+                  var kOrigin = options.origins[k];
+                  if (curOrigins.indexOf(kOrigin) < 0) {
+                    curOrigins.push(kOrigin);
+                  }
+                }
+                // Update origins in config object
+                putCorsConfig.CORSConfiguration.CORSRules[0].AllowedOrigins = curOrigins;
+                // Put Cors Config on the server
+                return client.putBucketCors(putCorsConfig, callback);
               }
             }
           });

--- a/lib/storage/s3.js
+++ b/lib/storage/s3.js
@@ -18,46 +18,6 @@ module.exports = function() {
 
   var self = {
     init: function (options, callback) {
-      // CORS Config Variables
-      if (options.cors) {
-        var getCorsConfig = {
-          Bucket: options.bucket
-        }
-        var putCorsConfig = {
-          Bucket: options.bucket,
-          CORSConfiguration: {
-            CORSRules: [{
-                AllowedHeaders: [
-                  "*"
-                ],
-                AllowedMethods: [
-                  "PUT",
-                  "POST",
-                  "DELETE"
-                ],
-                AllowedOrigins: options.origins,
-                ExposeHeaders: [
-                  "x-amz-server-side-encryption"
-                ],
-                MaxAgeSeconds: 3000
-              },
-              {
-                AllowedHeaders: [
-                  "Authorization"
-                ],
-                AllowedMethods: [
-                  "GET"
-                ],
-                AllowedOrigins: [
-                  "*"
-                ],
-                MaxAgeSeconds: 3000
-              }
-            ]
-          },
-          ContentMD5: ""
-        };
-      }
       endpoint = 's3.amazonaws.com';
       if (options.secret) {
         options.credentials = new AWS.Credentials(options.key, options.secret, options.token || null);
@@ -100,55 +60,6 @@ module.exports = function() {
       }
       https = options.https;
       cachingTime = options.cachingTime;
-      // CORS
-      if (options.cors) {
-        try {
-          return client.getBucketCors(getCorsConfig, function (err, data) {
-            if (err) {
-              // No CORS yet.
-              if (err.message.indexOf("The CORS configuration does not exist") >= 0) {
-                console.log("Creating CORS Config");
-                return client.putBucketCors(putCorsConfig, callback);
-                // Unexpected error
-              } else {
-                console.log("Unexpected error: ", err.message);
-                return callback(err);
-              }
-              // Successful response
-            } else {
-              if (_.isEqual(data.CORSRules, putCorsConfig.CORSConfiguration.CORSRules) == false) {
-                return callback(null);
-              } else {
-                // Collect all the existing origins
-                var curOrigins = new Array;
-                for (i = 0; i < data.CORSRules.length(); i++) {
-                  var iOrigins = data.CORSRules[i].AllowedOrigins;
-                  for (j = 0; j < iOrigins.length(); j++) {
-                    var origin = iOrigins[j];
-                    if (curOrigins.indexOf(origin) < 0 && origin != "*") {
-                      curOrigins.push(origin);
-                    }
-                  }
-                }
-                // Add new origins
-                for (k = 0; k < options.origins.length(); k++) {
-                  var kOrigin = options.origins[k];
-                  if (curOrigins.indexOf(kOrigin) < 0) {
-                    curOrigins.push(kOrigin);
-                  }
-                }
-                // Update origins in config object
-                putCorsConfig.CORSConfiguration.CORSRules[0].AllowedOrigins = curOrigins;
-                // Put Cors Config on the server
-                return client.putBucketCors(putCorsConfig, callback);
-              }
-            }
-          });
-        } catch (err) {
-          console.dir(err);
-          return callback(null);
-        }
-      }
       return callback(null);
     },
 

--- a/lib/storage/s3.js
+++ b/lib/storage/s3.js
@@ -100,26 +100,31 @@ module.exports = function() {
       }
       https = options.https;
       cachingTime = options.cachingTime;
+      // CORS
       if (options.cors) {
-        // CORS
-        return client.getBucketCors(getCorsConfig, function (err, data) {
-          if (err) {
-            // No CORS yet.
-            if (err.message == "NoSuchCORSConfiguration: The CORS configuration does not exist") {
-              return client.putBucketCors(putCorsConfig, callback);
-            // Unexpected error
+        try {
+          return client.getBucketCors(getCorsConfig, function (err, data) {
+            if (err) {
+              // No CORS yet.
+              if (err.message == "NoSuchCORSConfiguration: The CORS configuration does not exist") {
+                return client.putBucketCors(putCorsConfig, callback);
+                // Unexpected error
+              } else {
+                return callback(err);
+              }
+              // Successful response
             } else {
-              return callback(err);
+              if (_.isEqual(data.CORSRules, putCorsConfig.CORSConfiguration.CORSRules) == false) {
+                return client.putBucketCors(putCorsConfig, callback);
+              } else {
+                return callback(null);
+              }
             }
-          // Successful response
-          } else {
-            if (_.isEqual(data.CORSRules, putCorsConfig.CORSConfiguration.CORSRules) == false) {
-              return client.putBucketCors(putCorsConfig, callback);
-            } else {
-              return callback(null);
-            }
-          }
-        });
+          });
+        } catch (err) {
+          console.dir(err);
+          return callback(null);
+        }
       }
       return callback(null);
     },


### PR DESCRIPTION
Endpoint was already available as a configurable option. Adding images
to an S3 compatible service was functional, but getURL() was hardcoded
to use the standard s3 endpoint. Now, by default the s3 endpoint will be used, but the user configured endpoint will be used if it exists.