### PR TITLE
Add mime-type for svg

### DIFF
--- a/lib/storage/contentTypes.js
+++ b/lib/storage/contentTypes.js
@@ -282,6 +282,7 @@ module.exports =
   'jpe': 'image/jpeg',
   'pcx': 'image/pcx',
   'png': 'image/png',
+  'svg': 'image/svg+xml',
   'tiff': 'image/tiff',
   'tif': 'image/tiff',
   'cr2': 'image/x-canon-cr2',

--- a/lib/storage/s3.js
+++ b/lib/storage/s3.js
@@ -53,13 +53,11 @@ module.exports = function() {
         options.params.httpOptions.agent = options.params.httpOptions.agent || options.agent;
       }
       client = new AWS.S3(options);
+      defaultTypes = require(__dirname + "/contentTypes.js");
       if (options.contentTypes) {
-        contentTypes = options.contentTypes;
-        if (!contentTypes.svg) {
-          contentTypes.svg = 'image/svg+xml';
-        }
+        _.extend(contentTypes, defaultTypes, options.contentTypes);
       } else {
-        contentTypes = require(__dirname + '/contentTypes.js');
+        contentTypes = defaultTypes;
       }
       https = options.https;
       cachingTime = options.cachingTime;

--- a/lib/storage/s3.js
+++ b/lib/storage/s3.js
@@ -55,6 +55,9 @@ module.exports = function() {
       client = new AWS.S3(options);
       if (options.contentTypes) {
         contentTypes = options.contentTypes;
+        if (!contentTypes.svg) {
+          contentTypes.svg = 'image/svg+xml';
+        }
       } else {
         contentTypes = require(__dirname + '/contentTypes.js');
       }


### PR DESCRIPTION
I was having trouble with SVGs in apostrophe-cms not displaying when hosted on s3, and discovered it was because the content type is set to `application/octet-stream` by default, and svg didn't have a content-type specified. I've added its proper type, and included a check when using amazon's content-type list, as they don't currently include svg by default.