### PR TITLE
Two GCS improvements

### DIFF
--- a/gcsTestOptions-sample.js
+++ b/gcsTestOptions-sample.js
@@ -5,5 +5,6 @@ module.exports = {
   // If you are getting `Error: Invalid Grant`, this is likely your problem
   backend: 'gcs',
   bucket: 'yourownbucketnamefromgcs',
-  region: 'us-west-2'
+  region: 'us-west-2',
+  validation: false // Can be one of false, "md5" or  "crc32", YMMV
 };

--- a/lib/storage/gcs.js
+++ b/lib/storage/gcs.js
@@ -13,18 +13,21 @@ module.exports = function() {
   let cachingTime;
   let https;
   let bucketName;
-  let endpoint;
+  let endpoint = 'storage.googleapis.com';
   let defaultTypes;
   let noProtoEndpoint;
+  let validation = false;
 
   const self = {
     init: function (options, callback) {
       if (!(process.env.GOOGLE_APPLICATION_CREDENTIALS)) {
         return callback("GOOGLE_APPLICATION_CREDENTIALS not set in env, cannot proceed");
       }
+      if (options.validation) {
+        validation = options.validation;
+      }
       // Ultimately the result will look like https://storage.googleapis.com/[BUCKET_NAME]/[OBJECT_NAME]
       // The rest is based mostly on s3 knox surmises.
-      endpoint = 'storage.googleapis.com';
       if (options.endpoint) {
         endpoint = options.endpoint;
         if (!endpoint.match(/^https?:/)) {
@@ -62,8 +65,7 @@ module.exports = function() {
     },
 
     copyIn: function(localPath, path, options, callback) {
-      const cleanPath = cleanKey(path);
-      let ext = extname(cleanPath);
+      let ext = extname(path);
       if (ext.length) {
         ext = ext.substr(1);
       }
@@ -78,9 +80,10 @@ module.exports = function() {
         cacheControl = 'public, max-age=' + cachingTime;
       }
       const uploadOptions = {
-        destination: cleanPath,
+        destination: path,
         gzip: true,
         public: true,
+        validation: validation,
         metadata: {
           cacheControl: cacheControl,
           ContentType: contentType
@@ -90,7 +93,7 @@ module.exports = function() {
     },
 
     copyOut: function(path, localPath, options, callback) {
-      const mergedOptions = _.assign({ destination: cleanKey(localPath) }, options);
+      const mergedOptions = _.assign({ destination: localPath, validation: validation }, options);
       client.bucket(bucketName).file(path).download(mergedOptions, callback);
     },
 
@@ -99,11 +102,11 @@ module.exports = function() {
     },
 
     enable: function(path, callback) {
-      client.bucket(bucketName).file(cleanKey(path)).makePublic(callback);
+      client.bucket(bucketName).file(path).makePublic(callback);
     },
 
     disable: function(path, callback) {
-      client.bucket(bucketName).file(cleanKey(path)).makePrivate({}, callback);
+      client.bucket(bucketName).file(path).makePrivate({}, callback);
     },
 
     getUrl: function (path) {
@@ -118,9 +121,3 @@ module.exports = function() {
   };
   return self;
 };
-
-// Borrowed from the convention in S3 backend. Not sure it's needed here but it seems OK.
-
-function cleanKey(key) {
-  return key.replace(/^\//, '');
-}


### PR DESCRIPTION
I am offering some fixes for GCP discovered in development.

• Removes "cleanKey" function left over from assumptions in the S3 backend based on old Knox: it's problematic with the crop function in the attachments module. 

• The official Google Cloud Storage Client validates all local and remote operations using checksums. I was unable to get the client to not fail this step every single time a crop operation occurred. So I also made validation disabled by default in the module so that cropping actually works. I plan to do a deeper dive on this later, but for now, this suffices. 